### PR TITLE
Feat/main layout

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,7 +14,7 @@ module.exports = {
 	rules: {
 		'react/jsx-no-target-blank': 'off',
 		'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
-
+		'react/prop-types': 'off',
 		'no-unused-vars': 'off',
 		'camelcase': 'off',
 	},

--- a/src/components/Divider/index.jsx
+++ b/src/components/Divider/index.jsx
@@ -1,0 +1,3 @@
+export default function Divider() {
+	return <div>디바이더</div>;
+}

--- a/src/components/Divider/index.jsx
+++ b/src/components/Divider/index.jsx
@@ -1,3 +1,3 @@
 export default function Divider() {
-	return <div>디바이더</div>;
+	return <hr className="w-screen border-b-2 border-greyBD" />;
 }

--- a/src/components/Logo/Logo.jsx
+++ b/src/components/Logo/Logo.jsx
@@ -1,0 +1,10 @@
+import { Link } from 'react-router-dom';
+import logo from '../../assets/images/logo/logoEN.svg';
+
+export default function Logo() {
+	return (
+		<Link to="/main-page" className="flex h-16 w-32">
+			<img alt="logo" src={logo} />
+		</Link>
+	);
+}

--- a/src/components/MainContainer/index.jsx
+++ b/src/components/MainContainer/index.jsx
@@ -1,0 +1,7 @@
+export default function MainContainer({ children }) {
+	return (
+		<div className="mx-auto flex  w-4/6 flex-grow flex-col">
+			<div className="flex  flex-grow flex-col">{children}</div>
+		</div>
+	);
+}

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,12 +1,13 @@
 export const routes = {
-  main: "/main-page",
-  school: "/school-page",
-  region: "/region-page",
-  myPage: "/my-page",
-  auth: {
-    login: "/auth/login",
-    schoolSetting: "/auth/school",
-    regionSetting: "/auth/region",
-    profileSetting: "/auth/profile",
-  },
+	main: '/main-page',
+	about: '/about-page',
+	school: '/school-page',
+	region: '/region-page',
+	myPage: '/my-page',
+	auth: {
+		login: '/auth/login',
+		schoolSetting: '/auth/school',
+		regionSetting: '/auth/region',
+		profileSetting: '/auth/profile',
+	},
 };

--- a/src/layout/LoginLayout/Header/index.jsx
+++ b/src/layout/LoginLayout/Header/index.jsx
@@ -1,9 +1,9 @@
-import logo from '../../../assets/images/logo/logoEN.svg';
+import Logo from '../../../components/Logo/Logo';
 
 export default function Header() {
 	return (
 		<header className=" h-18 flex flex-row items-center justify-start bg-white ">
-			<img alt="logo" src={logo} className="flex h-16 w-32" />
+			<Logo />
 		</header>
 	);
 }

--- a/src/layout/MainLayout/Footer/index.jsx
+++ b/src/layout/MainLayout/Footer/index.jsx
@@ -1,3 +1,11 @@
 export default function Footer() {
-  return <div>footer</div>;
+	return (
+		<footer className=" my-auto flex h-28 w-full flex-col justify-center text-sm text-grey69">
+			<div className=" w-full">
+				<p>개인정보처리방침</p>
+				<p>서비스 이용약관</p>
+				<p>Contact | gitbal2019@gmail.com</p>
+			</div>
+		</footer>
+	);
 }

--- a/src/layout/MainLayout/Header/Navigation/NavGroup.jsx
+++ b/src/layout/MainLayout/Header/Navigation/NavGroup.jsx
@@ -1,0 +1,11 @@
+import NavItem from './NavItem';
+
+export default function NavGroup({ items }) {
+	return (
+		<ol className="ml-8 flex flex-row space-x-8 text-lg">
+			{items.children.map((item) => (
+				<NavItem key={item.id} url={item.url} title={item.title} />
+			))}
+		</ol>
+	);
+}

--- a/src/layout/MainLayout/Header/Navigation/NavItem.jsx
+++ b/src/layout/MainLayout/Header/Navigation/NavItem.jsx
@@ -1,0 +1,9 @@
+import { Link } from 'react-router-dom';
+
+export default function NavItem({ title, url }) {
+	return (
+		<li>
+			<Link to={url}>{title}</Link>
+		</li>
+	);
+}

--- a/src/layout/MainLayout/Header/Navigation/index.jsx
+++ b/src/layout/MainLayout/Header/Navigation/index.jsx
@@ -1,0 +1,10 @@
+import NavGroup from './NavGroup';
+import navItems from '../../../../nav-items';
+
+export default function Navigation() {
+	return (
+		<nav className="flex flex-row">
+			<NavGroup items={navItems.items} />
+		</nav>
+	);
+}

--- a/src/layout/MainLayout/Header/Profile/index.jsx
+++ b/src/layout/MainLayout/Header/Profile/index.jsx
@@ -1,0 +1,10 @@
+import { Link } from 'react-router-dom';
+import image from '../../../../assets/react.svg';
+
+export default function Profile() {
+	return (
+		<Link to={'/my-page'}>
+			<img src={image} className="h-8 w-8 rounded-full bg-black" />
+		</Link>
+	);
+}

--- a/src/layout/MainLayout/Header/Profile/index.jsx
+++ b/src/layout/MainLayout/Header/Profile/index.jsx
@@ -3,7 +3,7 @@ import image from '../../../../assets/react.svg';
 
 export default function Profile() {
 	return (
-		<Link to={'/my-page'}>
+		<Link to="/my-page">
 			<img src={image} className="h-8 w-8 rounded-full bg-black" />
 		</Link>
 	);

--- a/src/layout/MainLayout/Header/index.jsx
+++ b/src/layout/MainLayout/Header/index.jsx
@@ -1,4 +1,4 @@
-import logo from '../../../assets/images/logo/logoKO.svg';
+import logo from '../../../assets/images/logo/logoEN.svg';
 
 export default function Header() {
 	return (

--- a/src/layout/MainLayout/Header/index.jsx
+++ b/src/layout/MainLayout/Header/index.jsx
@@ -1,3 +1,9 @@
+import logo from '../../../assets/images/logo/logoKO.svg';
+
 export default function Header() {
-  return <header>헤더</header>;
+	return (
+		<header className=" h-18 flex flex-row items-center justify-start bg-white ">
+			<img alt="logo" src={logo} className="flex h-16 w-32" />
+		</header>
+	);
 }

--- a/src/layout/MainLayout/Header/index.jsx
+++ b/src/layout/MainLayout/Header/index.jsx
@@ -1,11 +1,17 @@
 import logo from '../../../assets/images/logo/logoEN.svg';
 import Navigation from './Navigation';
+import Profile from './Profile';
 
 export default function Header() {
 	return (
-		<header className=" h-18 flex flex-row items-center justify-start bg-white ">
-			<img alt="logo" src={logo} className="flex h-16 w-32" />
-			<Navigation />
+		<header className=" h-18 flex flex-row items-center justify-between bg-white ">
+			<div className="flex flex-row items-center justify-start">
+				<img alt="logo" src={logo} className="flex h-16 w-32" />
+				<Navigation />
+			</div>
+			<div className="flex flex-row items-center justify-start">
+				<Profile />
+			</div>
 		</header>
 	);
 }

--- a/src/layout/MainLayout/Header/index.jsx
+++ b/src/layout/MainLayout/Header/index.jsx
@@ -1,9 +1,11 @@
 import logo from '../../../assets/images/logo/logoEN.svg';
+import Navigation from './Navigation';
 
 export default function Header() {
 	return (
 		<header className=" h-18 flex flex-row items-center justify-start bg-white ">
 			<img alt="logo" src={logo} className="flex h-16 w-32" />
+			<Navigation />
 		</header>
 	);
 }

--- a/src/layout/MainLayout/Header/index.jsx
+++ b/src/layout/MainLayout/Header/index.jsx
@@ -1,4 +1,5 @@
 import logo from '../../../assets/images/logo/logoEN.svg';
+import Logo from '../../../components/Logo/Logo';
 import Navigation from './Navigation';
 import Profile from './Profile';
 
@@ -6,7 +7,7 @@ export default function Header() {
 	return (
 		<header className=" h-18 flex flex-row items-center justify-between bg-white ">
 			<div className="flex flex-row items-center justify-start">
-				<img alt="logo" src={logo} className="flex h-16 w-32" />
+				<Logo />
 				<Navigation />
 			</div>
 			<div className="flex flex-row items-center justify-start">

--- a/src/layout/MainLayout/index.jsx
+++ b/src/layout/MainLayout/index.jsx
@@ -1,13 +1,26 @@
-import { Outlet } from "react-router-dom";
-import Footer from "./Footer";
-import Header from "./Header";
+import { Outlet } from 'react-router-dom';
+
+import Footer from './Footer';
+import Header from './Header';
 
 export default function MainLayout() {
-  return (
-    <>
-      <Header />
-      <Outlet />
-      <Footer />
-    </>
-  );
+	return (
+		<div className=" flex min-h-screen w-screen flex-col">
+			<div className="sticky top-0 flex w-screen shadow-lg">
+				<div className="mx-auto w-4/6 ">
+					<Header />
+				</div>
+			</div>
+			<div className="mx-auto flex  w-4/6 flex-grow flex-col">
+				<div className="flex  flex-grow flex-col">
+					<Outlet />
+				</div>
+			</div>
+			<div className=" relative  mt-16 w-screen bg-greyD9">
+				<div className=" container mx-auto w-4/6">
+					<Footer />
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/layout/MainLayout/index.jsx
+++ b/src/layout/MainLayout/index.jsx
@@ -11,11 +11,7 @@ export default function MainLayout() {
 					<Header />
 				</div>
 			</div>
-			<div className="mx-auto flex  w-4/6 flex-grow flex-col">
-				<div className="flex  flex-grow flex-col">
-					<Outlet />
-				</div>
-			</div>
+			<Outlet />
 			<div className=" relative  mt-16 w-screen bg-greyD9">
 				<div className=" container mx-auto w-4/6">
 					<Footer />

--- a/src/nav-items/index.js
+++ b/src/nav-items/index.js
@@ -1,0 +1,27 @@
+const navItems = {
+	id: 'nav',
+	title: 'nav',
+	type: 'group',
+	children: [
+		{
+			id: 'about',
+			title: 'about',
+			type: 'item',
+			url: '/about',
+		},
+		{
+			id: 'schoolRank',
+			title: 'schoolRank',
+			type: 'item',
+			url: '/school-page',
+		},
+		{
+			id: 'regionalRank',
+			title: 'regionalRank',
+			type: 'item',
+			url: '/region-page',
+		},
+	],
+};
+
+export default navItems;

--- a/src/nav-items/index.js
+++ b/src/nav-items/index.js
@@ -1,27 +1,29 @@
 const navItems = {
-	id: 'nav',
-	title: 'nav',
-	type: 'group',
-	children: [
-		{
-			id: 'about',
-			title: 'about',
-			type: 'item',
-			url: '/about',
-		},
-		{
-			id: 'schoolRank',
-			title: 'schoolRank',
-			type: 'item',
-			url: '/school-page',
-		},
-		{
-			id: 'regionalRank',
-			title: 'regionalRank',
-			type: 'item',
-			url: '/region-page',
-		},
-	],
+	items: {
+		id: 'nav',
+		title: 'nav',
+		type: 'group',
+		children: [
+			{
+				id: 'about',
+				title: 'About',
+				type: 'item',
+				url: '/about-page',
+			},
+			{
+				id: 'schoolRank',
+				title: 'School Rank',
+				type: 'item',
+				url: '/school-page',
+			},
+			{
+				id: 'regionalRank',
+				title: 'Regional Rank',
+				type: 'item',
+				url: '/region-page',
+			},
+		],
+	},
 };
 
 export default navItems;

--- a/src/pages/AboutPage/index.jsx
+++ b/src/pages/AboutPage/index.jsx
@@ -1,0 +1,3 @@
+export default function About() {
+	return <>About</>;
+}

--- a/src/pages/AboutPage/index.jsx
+++ b/src/pages/AboutPage/index.jsx
@@ -1,3 +1,12 @@
+import Divider from '../../components/Divider';
+import MainContainer from '../../components/MainContainer';
+
 export default function AboutPage() {
-	return <>About</>;
+	return (
+		<>
+			<MainContainer>About</MainContainer>
+			<Divider />
+			<MainContainer>About</MainContainer>
+		</>
+	);
 }

--- a/src/pages/AboutPage/index.jsx
+++ b/src/pages/AboutPage/index.jsx
@@ -1,3 +1,3 @@
-export default function About() {
+export default function AboutPage() {
 	return <>About</>;
 }

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -1,3 +1,11 @@
+import Divider from '../../components/Divider';
+import MainContainer from '../../components/MainContainer';
+
 export default function MainPage() {
-  return <div>MainPage</div>;
+	return (
+		<>
+			<MainContainer>Main</MainContainer>
+			<MainContainer>Main</MainContainer>
+		</>
+	);
 }

--- a/src/pages/MyPage/index.jsx
+++ b/src/pages/MyPage/index.jsx
@@ -1,3 +1,12 @@
+import Divider from '../../components/Divider';
+import MainContainer from '../../components/MainContainer';
+
 export default function MyPage() {
-  return <div>마이페이지</div>;
+	return (
+		<>
+			<MainContainer>mypage</MainContainer>
+			<Divider />
+			<MainContainer>mypage</MainContainer>
+		</>
+	);
 }

--- a/src/pages/RegionPage/index.jsx
+++ b/src/pages/RegionPage/index.jsx
@@ -1,3 +1,12 @@
+import Divider from '../../components/Divider';
+import MainContainer from '../../components/MainContainer';
+
 export default function RegionPage() {
-  return <div>지역페이지</div>;
+	return (
+		<>
+			<MainContainer>region</MainContainer>
+			<Divider />
+			<MainContainer>region</MainContainer>
+		</>
+	);
 }

--- a/src/pages/SchoolPage/index.jsx
+++ b/src/pages/SchoolPage/index.jsx
@@ -1,3 +1,12 @@
+import Divider from '../../components/Divider';
+import MainContainer from '../../components/MainContainer';
+
 export default function SchoolPage() {
-  return <div>학교 페이지</div>;
+	return (
+		<>
+			<MainContainer>school</MainContainer>
+			<Divider />
+			<MainContainer>school</MainContainer>
+		</>
+	);
 }

--- a/src/routes/mainRoutes.jsx
+++ b/src/routes/mainRoutes.jsx
@@ -1,35 +1,40 @@
-import { Navigate } from "react-router-dom";
+import { Navigate } from 'react-router-dom';
 
-import MainLayout from "../layout/MainLayout";
-import { routes } from "../constants/routes";
-import MainPage from "../pages/MainPage";
-import SchoolPage from "../pages/SchoolPage";
-import RegionPage from "../pages/RegionPage";
-import MyPage from "../pages/MyPage";
+import MainLayout from '../layout/MainLayout';
+import { routes } from '../constants/routes';
+import MainPage from '../pages/MainPage';
+import SchoolPage from '../pages/SchoolPage';
+import RegionPage from '../pages/RegionPage';
+import MyPage from '../pages/MyPage';
+import AboutPage from '../pages/AboutPage';
 
 export const mainRoutes = {
-  path: "/",
-  element: <MainLayout />,
-  children: [
-    {
-      path: "/",
-      element: <Navigate replace to={routes.main} />,
-    },
-    {
-      path: routes.main,
-      element: <MainPage />,
-    },
-    {
-      path: routes.school,
-      element: <SchoolPage />,
-    },
-    {
-      path: routes.region,
-      element: <RegionPage />,
-    },
-    {
-      path: routes.myPage,
-      element: <MyPage />,
-    },
-  ],
+	path: '/',
+	element: <MainLayout />,
+	children: [
+		{
+			path: '/',
+			element: <Navigate replace to={routes.main} />,
+		},
+		{
+			path: routes.about,
+			element: <AboutPage />,
+		},
+		{
+			path: routes.main,
+			element: <MainPage />,
+		},
+		{
+			path: routes.school,
+			element: <SchoolPage />,
+		},
+		{
+			path: routes.region,
+			element: <RegionPage />,
+		},
+		{
+			path: routes.myPage,
+			element: <MyPage />,
+		},
+	],
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> 메인 레이아웃

## 📝작업 내용

>  - 메인 레이아웃 구현
>  - 네비게이션 구현 및 라우팅 
>  - 프로필 구현 및 라우팅
>  - 로고 컴포넌트 생성 및 라우팅
>  - 디바이더 구현 
>  - 메인 컨테이너 컴포넌트로 구현 후, 메인 레이아웃이 적용 될 각 컴포넌트에 적용 ( 화면이 디바이더 기준 2개로 분리되기 때문 )

### 스크린샷 (선택)

<img width="1728" alt="image" src="https://github.com/capstone-kw-jjiggle/gitbal-fe/assets/127329855/ed2903f6-3b87-4caf-825a-9e564b7b844b">

## 💬리뷰 요구사항(선택)

> 디바이더랑 메인 컨테이너는 추후 맡은 파트에 따라서 수정이 필요할듯 합니다. 따로 폴더를 만들어서 새로 만들어서 쓰면 될듯
